### PR TITLE
fix: sidebar collapsible triggers

### DIFF
--- a/apps/app/app/(authenticated)/components/sidebar.tsx
+++ b/apps/app/app/(authenticated)/components/sidebar.tsx
@@ -220,10 +220,12 @@ export const GlobalSidebar = ({ children }: GlobalSidebarProperties) => {
                 >
                   <SidebarMenuItem>
                     <SidebarMenuButton asChild tooltip={item.title}>
-                      <a href={item.url}>
-                        <item.icon />
-                        <span>{item.title}</span>
-                      </a>
+                      <CollapsibleTrigger asChild>
+                        <a href={item.url}>
+                          <item.icon />
+                          <span>{item.title}</span>
+                        </a>
+                      </CollapsibleTrigger>
                     </SidebarMenuButton>
                     {item.items?.length ? (
                       <>


### PR DESCRIPTION
## Description

Update the sidebar triggers by default to allow a user to click anywhere on the button to trigger the collapsible menu, not only on the small arrow icon.

## Related Issues

Closes #<issue_number>

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar navigation with improved collapsible functionality for menu items.
	- Integrated new components for better control over item visibility.

- **Bug Fixes**
	- Improved interaction model for toggling sub-item visibility in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->