### PR TITLE
fix: better dark/light support on unauthenticated

### DIFF
--- a/apps/app/app/(unauthenticated)/layout.tsx
+++ b/apps/app/app/(unauthenticated)/layout.tsx
@@ -9,15 +9,15 @@ type AuthLayoutProps = {
 const AuthLayout = ({ children }: AuthLayoutProps) => (
   <div className="container relative grid h-dvh flex-col items-center justify-center lg:max-w-none lg:grid-cols-2 lg:px-0">
     <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
-      <div className="absolute inset-0 bg-zinc-900" />
-      <div className="relative z-20 flex items-center font-medium text-lg">
+      <div className="absolute inset-0 bg-muted" />
+      <div className="relative z-20 flex items-center font-medium text-lg text-primary">
         <CommandIcon className="mr-2 h-6 w-6" />
         Acme Inc
       </div>
       <div className="absolute top-4 right-4">
         <ModeToggle />
       </div>
-      <div className="relative z-20 mt-auto">
+      <div className="relative z-20 mt-auto text-primary">
         <blockquote className="space-y-2">
           <p className="text-lg">
             &ldquo;This library has saved me countless hours of work and helped


### PR DESCRIPTION
## Description

The toggle on (unauthenticated) layout was disappearing when switching—this change prevents that

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

### Before

![CleanShot 2025-06-04 at 16 53 46](https://github.com/user-attachments/assets/91fa916b-4c26-4922-833f-4f43b3a1055e)

### After
(do note that in my own version I have a different method for ModeToggle that switches between the theme rather than displaying a dropdown).

![CleanShot 2025-06-04 at 16 54 38](https://github.com/user-attachments/assets/58fc3796-f57d-44ad-ad34-b1750824d7fb)
