### PR TITLE
fix: correct google analytics env

### DIFF
--- a/docs/content/docs/packages/analytics/web.mdx
+++ b/docs/content/docs/packages/analytics/web.mdx
@@ -17,7 +17,7 @@ Read more about it [here](https://vercel.com/docs/analytics/quickstart).
 
 Google Analytics tracks user behavior, page views, session duration, and other engagement metrics to provide insights into user activity and marketing effectiveness. GA tracking code is injected using [@next/third-parties](https://nextjs.org/docs/app/building-your-application/optimizing/third-party-libraries#google-analytics) for performance reasons.
 
-To enable it, simply add a `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` environment variable to your project.
+To enable it, simply add a `NEXT_PUBLIC_GA_MEASUREMENT_ID` environment variable to your project.
 
 ## PostHog
 


### PR DESCRIPTION
## Description

Fixes env var for Google Analytics in docs as it didn't match actual env var used in codebase (`NEXT_PUBLIC_GA_MEASUREMENT_ID`).

## Related Issues

n/a

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

Before
<img width="1624" height="448" alt="Screenshot - Dia - Web Analytics (2025-07-13 at 14 38 00)@2x" src="https://github.com/user-attachments/assets/578e70ee-25a0-4d28-9eea-217301ab363e" />

After
<img width="1560" height="436" alt="Screenshot - Dia - Web Analytics (2025-07-13 at 14 38 24)@2x" src="https://github.com/user-attachments/assets/a98c1f56-551d-4348-b74a-02d9be94f81e" />
