### PR TITLE
fix: add missing --dir flag to email build and export scripts

### DIFF
--- a/apps/email/package.json
+++ b/apps/email/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "email build",
+    "build": "email build --dir ../../packages/email/templates",
     "dev": "email dev --port 3003 --dir ../../packages/email/templates",
-    "export": "email export",
+    "export": "email export --dir ../../packages/email/templates",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },


### PR DESCRIPTION
## Summary
- Added `--dir` flag to `build` and `export` scripts in apps/email/package.json
- Points to the correct email templates location at `../../packages/email/templates`
- Matches the existing configuration in the `dev` script

## Problem
The email app build was failing because the react-email CLI defaults to looking for templates in `./emails` relative to where the command runs, but the actual templates are in `packages/email/templates`.

## Solution
Updated the scripts to explicitly specify the templates directory path using the `--dir` flag.

Fixes #619