### PR TITLE
fix: Refactor PrismaNeon initialization to use PoolConfig instead of Pool directly

### DIFF
--- a/packages/database/index.ts
+++ b/packages/database/index.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { neonConfig, Pool } from "@neondatabase/serverless";
+import { neonConfig } from "@neondatabase/serverless";
 import { PrismaNeon } from "@prisma/adapter-neon";
 import ws from "ws";
 import { PrismaClient } from "./generated/client";
@@ -10,8 +10,7 @@ const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 neonConfig.webSocketConstructor = ws;
 
-const pool = new Pool({ connectionString: keys().DATABASE_URL });
-const adapter = new PrismaNeon(pool);
+const adapter = new PrismaNeon({ connectionString: keys().DATABASE_URL });
 
 export const database = globalForPrisma.prisma || new PrismaClient({ adapter });
 


### PR DESCRIPTION
## Description

This PR fixes a runtime error caused by passing a `Pool` instance into the `PrismaNeon` adapter instead of a `PoolConfig` object. The adapter expects a configuration object (with a `connectionString`), but the code constructed and passed a `Pool`, which lacks the expected `connectionString` property. Prisma's client then fell back to default host/user values and produced the runtime error:

“No database host or connection string was set, and key parameters have default values (host: localhost, user: ryan, db: ryan, password: null)...”

The change updates the PrismaNeon initialization to pass the expected `PoolConfig` object with the `connectionString` taken from `DATABASE_URL`.

## Related Issues

Closes #643

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works. **I verified manually**.
- [x] New and existing tests pass locally with my changes.

Notes:
- This fix is small and targeted; it should not affect other database behavior because it only changes how the Neon adapter is constructed.
- I validated that `pnpm migrate` works and confirmed the root cause and fix in issue comments.

## Screenshots (if applicable)

N/A

## Additional Notes

Root cause and reproduction details are available in the original issue: https://github.com/vercel/next-forge/issues/643
