### PR TITLE
fix: email pkg tsconfig to encompass .ts(x) files

### DIFF
--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["./*.ts", "./*.tsx"],
+  "include": ["./**/*.ts", "./**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description

Old `tsconfig.json` did not include `.tsx` files in the `./templates` folder and was showing errors per screenshot below. Minor fix!

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<img width="924" height="304" alt="Screenshot - Cursor - contact tsx — flourish (2025-11-06 at 21 34 09)@2x" src="https://github.com/user-attachments/assets/dd3bd9cb-2f66-4852-bfb0-0546c409dbf9" />