### PR TITLE
fix(database): load database vars from env file

### DIFF
--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Description

Fix `npm run migrate` failing with "Connection url is empty" by loading environment variables in the Prisma config

`prisma.config.ts` reads `process.env.DATABASE_URL` to configure the datasource, but Prisma CLI does not auto-load `.env` files when using a TypeScript config. This caused the URL to resolve to an empty string, breaking all migration commands.

Adding `import "dotenv/config"` ensures the `.env` file is loaded before the environment variable is accessed.

## Related Issues

Closes #738

## Checklist

- [X] My code follows the code style of this project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests that prove my fix is effective or my feature works.
- [X] New and existing tests pass locally with my changes.
