### PR TITLE
fix: add .npmrc legacy-peer-deps to resolve zod v4 peer dep conflict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

Fixes #743

- `@repo/payments` uses `zod@^4.3.6`, but `@stripe/agent-toolkit@0.9.0` → `openai@4.104.0` declares `peerOptional zod@"^3.23.8"`.
- npm's strict peer dep resolution (v7+) errors with `ERESOLVE` even for optional peer deps when an incompatible version is already present, blocking `npx next-forge@latest init` for npm users.
- Adding `legacy-peer-deps=true` to a root-level `.npmrc` tells npm to use the pre-v7 algorithm, allowing the dependency tree to resolve without errors.

## Root Cause

`openai@4.x` only accepts zod v3 as an optional peer dep. When `zod@4.x` is installed in the same workspace, npm v7+ treats this as an irreconcilable conflict and aborts installation — even though it's marked `peerOptional`.

## Fix

Added `.npmrc` at the monorepo root with:
```
legacy-peer-deps=true
```

## Test plan

- [ ] Run `npx next-forge@latest init` on a Windows machine with npm — installation should complete without `ERESOLVE` errors
- [ ] Verify existing `bun install` workflow is unaffected (bun ignores `.npmrc` peer-dep settings)