### PR TITLE
fix: resolve zod v4 peer dep conflict in @repo/payments via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "nypm": "^0.6.5"
   },
   "overrides": {
-    "parse5": "^7.2.1"
+    "parse5": "^7.2.1",
+    "openai": {
+      "zod": "^4.3.6"
+    }
   },
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## Summary

Fixes #743

`@repo/payments` uses `zod@^4.3.6`, but `@stripe/agent-toolkit@0.9.0` pulls in `openai@4.x` which declares `peerOptional zod@"^3.23.8"`. npm v7+ fails with `ERESOLVE` even for optional peer deps when an incompatible version is already installed — blocking `npx next-forge@latest init` for npm users.

## Root Cause

The dependency chain:
```
@repo/payments → @stripe/agent-toolkit@^0.9.0
                       → openai@^4.86.1 (peerOptional zod@"^3.23.8")
@repo/payments → zod@^4.3.6  ← conflicts with openai's peer dep range
```

## Fix

Added a targeted `overrides` entry in the root `package.json` (which already contains an `overrides` block for `parse5`):

```json
"overrides": {
  "parse5": "^7.2.1",
  "openai": {
    "zod": "^4.3.6"
  }
}
```

This tells npm's resolver to use `zod@^4.3.6` when resolving `openai`'s peer dep, eliminating the `ERESOLVE` error without disabling peer dep validation globally.

## Test plan

- [ ] Run `npx next-forge@latest init` with npm on Windows — `npm install` should complete without `ERESOLVE` errors
- [ ] Verify `bun install` is unaffected (bun ignores npm `overrides`)