### PR TITLE
api/webhooks/auth: fix 'Error occured' -> 'Error occurred' response bodies

### DIFF
--- a/apps/api/app/webhooks/auth/route.ts
+++ b/apps/api/app/webhooks/auth/route.ts
@@ -157,7 +157,7 @@ export const POST = async (request: Request): Promise<Response> => {
 
   // If there are no headers, error out
   if (!(svixId && svixTimestamp && svixSignature)) {
-    return new Response("Error occured -- no svix headers", {
+    return new Response("Error occurred -- no svix headers", {
       status: 400,
     });
   }
@@ -180,7 +180,7 @@ export const POST = async (request: Request): Promise<Response> => {
     }) as WebhookEvent;
   } catch (error) {
     log.error("Error verifying webhook:", { error });
-    return new Response("Error occured", {
+    return new Response("Error occurred", {
       status: 400,
     });
   }


### PR DESCRIPTION
Two `Response(...)` bodies in `apps/api/app/webhooks/auth/route.ts` (lines 160 and 183) read `Error occured -- no svix headers` and `Error occured`. Both are returned as the response body text for Clerk webhook verification failures and reach end users. String-literal-only change.